### PR TITLE
feat: Change webhook authentication to use X-Webhook-Secret header

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,10 @@ POST /webhook
 **認証方法:**
 
 ```bash
-# リクエストボディまたはクエリパラメータでsecretを送信
+# X-Webhook-Secretヘッダーでsecretを送信
 curl -X POST http://localhost:8080/webhook \
   -H "Content-Type: application/json" \
-  -d '{"secret": "your_webhook_secret"}'
-
-# または
-curl -X POST "http://localhost:8080/webhook?secret=your_webhook_secret"
+  -H "X-Webhook-Secret: your_webhook_secret"
 ```
 
 **レスポンス（成功時）:**
@@ -271,7 +268,7 @@ curl -X POST "http://localhost:8080/webhook?secret=your_webhook_secret"
 # 習慣作成を実行
 curl -X POST http://localhost:8080/webhook \
   -H "Content-Type: application/json" \
-  -d '{"secret": "your_webhook_secret"}'
+  -H "X-Webhook-Secret: your_webhook_secret"
 
 # ヘルスチェック
 curl http://localhost:8080/health
@@ -284,7 +281,7 @@ curl http://localhost:8080/health
   run: |
     curl -X POST ${{ secrets.WEBHOOK_URL }}/webhook \
       -H "Content-Type: application/json" \
-      -d '{"secret": "${{ secrets.WEBHOOK_SECRET }}"}'
+      -H "X-Webhook-Secret: ${{ secrets.WEBHOOK_SECRET }}"
 ```
 
 ### 自動化ツール
@@ -297,11 +294,11 @@ curl http://localhost:8080/health
 ```bash
 # 毎朝7時に実行（crontab例）
 # 注意: 7時に実行すると、その日（今日）の習慣が作成されます
-0 7 * * * curl -X POST http://localhost:8080/webhook -d '{"secret":"your_secret"}'
+0 7 * * * curl -X POST http://localhost:8080/webhook -H "X-Webhook-Secret: your_secret"
 
 # 前日の夜に実行する場合（推奨）
 # 23時に実行すると、翌日の習慣が作成されます
-0 23 * * * curl -X POST http://localhost:8080/webhook -d '{"secret":"your_secret"}'
+0 23 * * * curl -X POST http://localhost:8080/webhook -H "X-Webhook-Secret: your_secret"
 ```
 
 ## 🛠️ 開発
@@ -440,8 +437,8 @@ echo $NOTION_API_KEY
 
 ```bash
 # エラー: Unauthorized webhook request
-# 解決: リクエストにsecretパラメータが含まれているか確認
-curl -X POST http://localhost:8080/webhook -d '{"secret": "your_secret"}'
+# 解決: リクエストにX-Webhook-Secretヘッダーが含まれているか確認
+curl -X POST http://localhost:8080/webhook -H "X-Webhook-Secret: your_secret"
 ```
 
 #### 4. ポートが使用中

--- a/app/src/types/__tests__/index.test.ts
+++ b/app/src/types/__tests__/index.test.ts
@@ -93,29 +93,33 @@ describe('Core Data Model Interfaces', () => {
   });
 
   describe('WebhookRequest interface', () => {
-    it('should accept valid webhook request', () => {
+    it('should accept valid webhook request with timestamp', () => {
       const validRequest: WebhookRequest = {
-        secret: 'test-secret-123',
         timestamp: Date.now(),
       };
 
       expect(isWebhookRequest(validRequest)).toBe(true);
     });
 
-    it('should accept webhook request without timestamp', () => {
+    it('should accept webhook request with action', () => {
       const validRequest: WebhookRequest = {
-        secret: 'test-secret-123',
+        action: 'schedule_habits',
+        timestamp: Date.now(),
       };
 
       expect(isWebhookRequest(validRequest)).toBe(true);
     });
 
-    it('should reject webhook request without secret', () => {
-      const invalidRequest = {
-        timestamp: Date.now(),
-      };
+    it('should accept empty webhook request', () => {
+      const validRequest: WebhookRequest = {};
 
-      expect(isWebhookRequest(invalidRequest)).toBe(false);
+      expect(isWebhookRequest(validRequest)).toBe(true);
+    });
+
+    it('should reject non-object webhook request', () => {
+      expect(isWebhookRequest(null)).toBe(false);
+      expect(isWebhookRequest('string')).toBe(false);
+      expect(isWebhookRequest(123)).toBe(false);
     });
   });
 

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -39,10 +39,11 @@ export interface SystemConfig {
 
 /**
  * Incoming webhook request structure
+ * Note: Authentication is handled via X-Webhook-Secret header
  */
 export interface WebhookRequest {
-  secret: string; // Required security parameter
   timestamp?: number;
+  action?: string; // Optional action parameter for future extensibility
 }
 
 /**
@@ -246,13 +247,14 @@ export function isHabitConfig(obj: any): obj is HabitConfig {
 
 /**
  * Type guard for checking if an object is a valid WebhookRequest
+ * Note: Authentication is validated separately via X-Webhook-Secret header
  */
 export function isWebhookRequest(obj: any): obj is WebhookRequest {
   return (
     typeof obj === 'object' &&
     obj !== null &&
-    typeof obj.secret === 'string' &&
-    (obj.timestamp === undefined || typeof obj.timestamp === 'number')
+    (obj.timestamp === undefined || typeof obj.timestamp === 'number') &&
+    (obj.action === undefined || typeof obj.action === 'string')
   );
 }
 

--- a/app/src/webhook-server.ts
+++ b/app/src/webhook-server.ts
@@ -77,11 +77,11 @@ export class WebhookServer {
    * Requirements: 8.1, 8.2
    */
   private validateSecret(request: Request): boolean {
-    // Check for secret in request body first, then query parameters
-    const providedSecret = request.body?.secret || request.query?.secret;
+    // Check for secret in X-Webhook-Secret header
+    const providedSecret = request.headers['x-webhook-secret'];
 
     if (!providedSecret) {
-      console.warn('Webhook request missing secret parameter');
+      console.warn('Webhook request missing X-Webhook-Secret header');
       return false;
     }
 

--- a/bin/test-webhook.sh
+++ b/bin/test-webhook.sh
@@ -87,7 +87,8 @@ echo ""
 WEBHOOK_RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" \
     -X POST \
     -H "Content-Type: application/json" \
-    -d "{\"secret\": \"${WEBHOOK_SECRET}\"}" \
+    -H "X-Webhook-Secret: ${WEBHOOK_SECRET}" \
+    -d '{}' \
     "${BASE_URL}/webhook")
 
 HTTP_STATUS=$(echo "$WEBHOOK_RESPONSE" | grep "HTTP_STATUS" | cut -d: -f2)


### PR DESCRIPTION
## 概要
Webhook認証方式をリクエストボディ/クエリパラメータから、HTTPヘッダーベースに変更しました。

## 変更内容

### コード変更
- **webhook-server.ts**: `validateSecret()`メソッドを更新し、`X-Webhook-Secret`ヘッダーから認証情報を取得
- **types/index.ts**: `WebhookRequest`インターフェースから`secret`フィールドを削除し、`action`フィールドを追加
- **types/__tests__/index.test.ts**: テストケースを更新してヘッダーベース認証に対応

### テストスクリプト
- **bin/test-webhook.sh**: `X-Webhook-Secret`ヘッダーを使用するように更新

### ドキュメント
- **README.md**: 全てのcurlコマンド例を更新
- **design.md**: セキュリティセクションを更新し、タイミング攻撃対策を明記

## 変更理由
- より標準的なHTTPヘッダーベースの認証方式に統一
- リクエストボディを認証に使用しないことで、ボディの柔軟性が向上
- セキュリティのベストプラクティスに準拠
- NotionのオートメーションにおけるWebhookの送信がヘッダーのみにしか対応していない

## 使用方法（変更後）
```bash
curl -X POST https://notion-automatic-habits-insert.argondev22.com/webhook \
  -H "Content-Type: application/json" \
  -H "X-Webhook-Secret: your_secret"
```

## テスト結果
✅ 全てのユニットテスト合格（81テスト）
✅ TypeScriptビルド成功

## 破壊的変更
⚠️ この変更は破壊的変更です。既存のWebhook呼び出し元は、リクエストボディの`secret`パラメータから`X-Webhook-Secret`ヘッダーに変更する必要があります。

## 関連Issue
Closes #70